### PR TITLE
Fix: admission controller error while receiving CREATE request

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -19,7 +19,6 @@ webhooks:
         apiVersions:
           - v1
         operations:
-          - CREATE
           - UPDATE
         resources:
           - scyllaclusters


### PR DESCRIPTION
Admission controller throwing error while receiving empty oldObject field in the request.